### PR TITLE
Refactored Spell activities to use authenticated e-mail

### DIFF
--- a/app/src/main/java/dev/tdwalsh/project/tabletopBeholder/activity/spell/CreateSpellActivity.java
+++ b/app/src/main/java/dev/tdwalsh/project/tabletopBeholder/activity/spell/CreateSpellActivity.java
@@ -37,10 +37,12 @@ public class CreateSpellActivity {
 
     public CreateSpellResult handleRequest(CreateSpellRequest createSpellRequest) {
         //First, assigned contained object to new variable
+        //Then, pulls userEmail from the authenticated email field in the request
         //Then, checks name for uniqueness
         //Then, uses the create helper to finish building the object
         //Finally, returns the newly created object
         Spell spell = createSpellRequest.getSpell();
+        spell.setUserEmail(createSpellRequest.getUserEmail());
         NameHelper.objectNameUniqueness(spellDao, spell);
 
         return CreateSpellResult.builder()

--- a/app/src/main/java/dev/tdwalsh/project/tabletopBeholder/activity/spell/GetSpellActivity.java
+++ b/app/src/main/java/dev/tdwalsh/project/tabletopBeholder/activity/spell/GetSpellActivity.java
@@ -37,7 +37,7 @@ public class GetSpellActivity {
     public GetSpellResult handleRequest(GetSpellRequest getSpellRequest) {
         Spell spell = spellDao.getSingle(getSpellRequest.getUserEmail(), getSpellRequest.getObjectId());
         if (spell == null) {
-            throw new SpellNotFoundException();
+            throw new SpellNotFoundException(String.format("Could not find a spell for [%s] with id [%s]", getSpellRequest.getUserEmail(), getSpellRequest.getObjectId()));
         }
         return GetSpellResult.builder()
                 .withSpell(spell)

--- a/app/src/main/java/dev/tdwalsh/project/tabletopBeholder/activity/spell/UpdateSpellActivity.java
+++ b/app/src/main/java/dev/tdwalsh/project/tabletopBeholder/activity/spell/UpdateSpellActivity.java
@@ -43,11 +43,13 @@ public class UpdateSpellActivity {
 
     public UpdateSpellResult handleRequest(UpdateSpellRequest updateSpellRequest) {
         //First, assigns the updated object to a new variable
+        //Then, pulls userEmail from the authenticated email field in the request
         //Then, retrieves the previous version from the DB, or throws an error if it does not exist
         //Then, if the name has changed, checks for name uniqueness, and throws an error if violated
         //Then, writes the new version to the DB
         //Finally, returns the updated version
         Spell newSpell  = updateSpellRequest.getSpell();
+        newSpell.setUserEmail(updateSpellRequest.getUserEmail());
         Spell oldSpell = Optional.ofNullable(spellDao.getSingle(newSpell.getUserEmail(), newSpell.getObjectId())).orElseThrow(() -> new MissingResourceException(String.format("Resource with id [%s] could not be retrieved from database", newSpell.getObjectId())));
         if (!newSpell.getObjectName().equals(oldSpell.getObjectName())) {
             NameHelper.objectNameUniqueness(spellDao, newSpell);

--- a/app/src/main/java/dev/tdwalsh/project/tabletopBeholder/activity/spell/request/CreateSpellRequest.java
+++ b/app/src/main/java/dev/tdwalsh/project/tabletopBeholder/activity/spell/request/CreateSpellRequest.java
@@ -9,14 +9,19 @@ import java.util.List;
 @JsonDeserialize(builder = CreateSpellRequest.Builder.class)
 public class CreateSpellRequest {
     private final Spell spell;
+    private final String userEmail;
 
-    private CreateSpellRequest(Spell spell) {
+    private CreateSpellRequest(Spell spell, String userEmail) {
+
         this.spell = spell;
+        this.userEmail = userEmail;
     }
 
     public Spell getSpell() {
         return this.spell;
     }
+
+    public String getUserEmail() { return this.userEmail; }
 
     public static Builder builder() {
         return new Builder();
@@ -24,13 +29,20 @@ public class CreateSpellRequest {
 
     public static class Builder {
         private Spell spell;
+        private String userEmail;
 
         public Builder withSpell(Spell spell) {
             this.spell = spell;
             return this;
         }
+
+        public Builder withUserEmail(String userEmail) {
+            this.userEmail = userEmail;
+            return this;
+        }
+
         public CreateSpellRequest build() {
-            return new CreateSpellRequest(spell);
+            return new CreateSpellRequest(spell, userEmail);
         }
     }
 }

--- a/app/src/main/java/dev/tdwalsh/project/tabletopBeholder/activity/spell/request/UpdateSpellRequest.java
+++ b/app/src/main/java/dev/tdwalsh/project/tabletopBeholder/activity/spell/request/UpdateSpellRequest.java
@@ -8,201 +8,39 @@ import java.util.List;
 @JsonDeserialize(builder = UpdateSpellRequest.Builder.class)
 public class UpdateSpellRequest {
     private final Spell spell;
-//    private final String userEmail;
-//    private final String objectId;
-//    private final String objectName;
-//    private final String spellDescription;
-//    private final String spellHigherLevel;
-//    private final String spellRange;
-//    private final String spellComponents;
-//    private final String spellMaterial;
-//    private final Boolean ritualCast;
-//    private final Integer castingTime;
-//    private final Integer spellLevel;
-//    private final String spellSchool;
-//    private final List<Effect> appliesEffects;
+    private final String userEmail;
 
-
-    private UpdateSpellRequest(Spell spell) {
+    private UpdateSpellRequest(Spell spell, String userEmail) {
         this.spell = spell;
+        this.userEmail = userEmail;
     }
 
     public Spell getSpell() {
         return this.spell;
     }
-//    private UpdateSpellRequest(String userEmail,
-//                               String objectId,
-//                               String objectName,
-//                               String spellDescription,
-//                               String spellHigherLevel,
-//                               String spellRange,
-//                               String spellComponents,
-//                               String spellMaterial,
-//                               Boolean ritualCast,
-//                               Integer castingTime,
-//                               Integer spellLevel,
-//                               String spellSchool,
-//                               List<Effect> appliesEffects) {
-//        this.userEmail = userEmail;
-//        this.objectId = objectId;
-//        this.objectName = objectName;
-//        this.spellDescription = spellDescription;
-//        this.spellHigherLevel = spellHigherLevel;
-//        this.spellRange = spellRange;
-//        this.spellComponents = spellComponents;
-//        this.spellMaterial = spellMaterial;
-//        this.ritualCast = ritualCast;
-//        this.castingTime = castingTime;
-//        this.spellLevel = spellLevel;
-//        this.spellSchool = spellSchool;
-//        this.appliesEffects = appliesEffects;
-//    }
-//
-//    public String getUserEmail() {
-//        return this.userEmail;
-//    }
-//
-//    public String getObjectId() { return this.objectId; }
-//
-//    public String getObjectName() { return this.objectName; }
-//
-//    public String getSpellDescription() {
-//        return spellDescription;
-//    }
-//
-//    public String getSpellHigherLevel() {
-//        return spellHigherLevel;
-//    }
-//
-//    public String getSpellRange() {
-//        return spellRange;
-//    }
-//
-//    public String getSpellComponents() {
-//        return spellComponents;
-//    }
-//
-//    public String getSpellMaterial() {
-//        return spellMaterial;
-//    }
-//
-//    public Boolean getRitualCast() {
-//        return ritualCast;
-//    }
-//
-//    public Integer getCastingTime() {
-//        return castingTime;
-//    }
-//
-//    public Integer getSpellLevel() {
-//        return spellLevel;
-//    }
-//
-//    public String getSpellSchool() {
-//        return spellSchool;
-//    }
-//
-//    public List<Effect> getAppliesEffects() {
-//        return appliesEffects;
-//    }
+
+    public String getUserEmail() { return this.userEmail; }
 
     public static Builder builder() {
         return new Builder();
     }
-//    public static class Builder {
-//        private String userEmail;
-//        private String objectId;
-//        private String objectName;
-//        private String spellDescription;
-//        private String spellHigherLevel;
-//        private String spellRange;
-//        private String spellComponents;
-//        private String spellMaterial;
-//        private Boolean ritualCast;
-//        private Integer castingTime;
-//        private Integer spellLevel;
-//        private String spellSchool;
-//        private List<Effect> appliesEffects;
-//
-//        public Builder withUserEmail(String userEmail) {
-//            this.userEmail = userEmail;
-//            return this;
-//        }
-//
-//        public Builder withObjectId(String objectId) {
-//            this.objectId = objectId;
-//            return this;
-//        }
-//
-//        public Builder withObjectName(String objectName) {
-//            this.objectName = objectName;
-//            return this;
-//        }
-//        public Builder withSpellDescription(String spellDescription) {
-//            this.spellDescription = spellDescription;
-//            return this;
-//        }
-//        public Builder withSpellHigherLevel(String spellHigherLevel) {
-//            this.spellHigherLevel = spellHigherLevel;
-//            return this;
-//        }
-//        public Builder withSpellRange(String spellRange) {
-//            this.spellRange = spellRange;
-//            return this;
-//        }
-//        public Builder withSpellComponents(String spellComponents) {
-//            this.spellComponents = spellComponents;
-//            return this;
-//        }
-//        public Builder withSpellMaterial(String spellMaterial) {
-//            this.spellMaterial = spellMaterial;
-//            return this;
-//        }
-//        public Builder withRitualCast(Boolean ritualCast) {
-//            this.ritualCast = ritualCast;
-//            return this;
-//        }
-//        public Builder withCastingTime(Integer castingTime) {
-//            this.castingTime = castingTime;
-//            return this;
-//        }public Builder withSpellLevel(Integer spellLevel) {
-//            this.spellLevel = spellLevel;
-//            return this;
-//        }
-//        public Builder withSpellSchool(String spellSchool) {
-//            this.spellSchool = spellSchool;
-//            return this;
-//        }public Builder withAppliesEffects(List<Effect> appliesEffects) {
-//            this.appliesEffects = appliesEffects;
-//            return this;
-//        }
-//
-//        public UpdateSpellRequest build() {
-//            return new UpdateSpellRequest(userEmail,
-//                                            objectId,
-//                                            objectName,
-//                                            spellDescription,
-//                                            spellHigherLevel,
-//                                            spellRange,
-//                                            spellComponents,
-//                                            spellMaterial,
-//                                            ritualCast,
-//                                            castingTime,
-//                                            spellLevel,
-//                                            spellSchool,
-//                                            appliesEffects);
-//        }
-//    }
+
 public static class Builder {
         private Spell spell;
+        private String userEmail;
 
         public Builder withSpell(Spell spell) {
             this.spell = spell;
             return this;
         }
 
+    public Builder withUserEmail(String userEmail) {
+        this.userEmail = userEmail;
+        return this;
+    }
+
         public UpdateSpellRequest build() {
-            return new UpdateSpellRequest(spell);
+            return new UpdateSpellRequest(spell, userEmail);
         }
 }
 

--- a/app/src/main/java/dev/tdwalsh/project/tabletopBeholder/lambda/spell/CreateSpellLambda.java
+++ b/app/src/main/java/dev/tdwalsh/project/tabletopBeholder/lambda/spell/CreateSpellLambda.java
@@ -6,18 +6,29 @@ import dev.tdwalsh.project.tabletopBeholder.activity.spell.request.CreateSpellRe
 import dev.tdwalsh.project.tabletopBeholder.activity.spell.request.GetSpellRequest;
 import dev.tdwalsh.project.tabletopBeholder.activity.spell.result.CreateSpellResult;
 import dev.tdwalsh.project.tabletopBeholder.activity.spell.result.GetSpellResult;
+import dev.tdwalsh.project.tabletopBeholder.dynamodb.models.Spell;
+import dev.tdwalsh.project.tabletopBeholder.lambda.AuthenticatedLambdaRequest;
 import dev.tdwalsh.project.tabletopBeholder.lambda.LambdaActivityRunner;
 import dev.tdwalsh.project.tabletopBeholder.lambda.LambdaRequest;
 import dev.tdwalsh.project.tabletopBeholder.lambda.LambdaResponse;
 
 public class CreateSpellLambda
         extends LambdaActivityRunner<CreateSpellRequest, CreateSpellResult>
-        implements RequestHandler<LambdaRequest<CreateSpellRequest>, LambdaResponse> {
+        implements RequestHandler<AuthenticatedLambdaRequest<CreateSpellRequest>, LambdaResponse> {
 
     @Override
-    public LambdaResponse handleRequest(LambdaRequest<CreateSpellRequest> input, Context context) {
+    public LambdaResponse handleRequest(AuthenticatedLambdaRequest<CreateSpellRequest> input, Context context) {
         return super.runActivity(
-                () -> input.fromBody(CreateSpellRequest.class),
+                () ->
+                {
+                    CreateSpellRequest stageRequest = input.fromBody(CreateSpellRequest.class);
+
+                    return input.fromUserClaims(claims ->
+                            CreateSpellRequest.builder()
+                                    .withUserEmail(claims.get("email"))
+                                    .withSpell(stageRequest.getSpell())
+                                    .build());
+                },
                 (request, serviceComponent) ->
                         serviceComponent.provideCreateSpellActivity().handleRequest(request)
         );

--- a/app/src/main/java/dev/tdwalsh/project/tabletopBeholder/lambda/spell/GetAllSpellsLambda.java
+++ b/app/src/main/java/dev/tdwalsh/project/tabletopBeholder/lambda/spell/GetAllSpellsLambda.java
@@ -6,20 +6,21 @@ import dev.tdwalsh.project.tabletopBeholder.activity.spell.request.GetAllSpellsR
 import dev.tdwalsh.project.tabletopBeholder.activity.spell.request.GetSpellRequest;
 import dev.tdwalsh.project.tabletopBeholder.activity.spell.result.GetAllSpellsResult;
 import dev.tdwalsh.project.tabletopBeholder.activity.spell.result.GetSpellResult;
+import dev.tdwalsh.project.tabletopBeholder.lambda.AuthenticatedLambdaRequest;
 import dev.tdwalsh.project.tabletopBeholder.lambda.LambdaActivityRunner;
 import dev.tdwalsh.project.tabletopBeholder.lambda.LambdaRequest;
 import dev.tdwalsh.project.tabletopBeholder.lambda.LambdaResponse;
 
 public class GetAllSpellsLambda
         extends LambdaActivityRunner<GetAllSpellsRequest, GetAllSpellsResult>
-        implements RequestHandler<LambdaRequest<GetAllSpellsRequest>, LambdaResponse> {
+        implements RequestHandler<AuthenticatedLambdaRequest<GetAllSpellsRequest>, LambdaResponse> {
 
     @Override
-    public LambdaResponse handleRequest(LambdaRequest<GetAllSpellsRequest> input, Context context) {
+    public LambdaResponse handleRequest(AuthenticatedLambdaRequest<GetAllSpellsRequest> input, Context context) {
         return super.runActivity(
-                () -> input.fromPath(path ->
+                () -> input.fromUserClaims(claims ->
                         GetAllSpellsRequest.builder()
-                                .withUserEmail(path.get("userEmail"))
+                                .withUserEmail(claims.get("userEmail"))
                                 .build()),
                 (request, serviceComponent) ->
                         serviceComponent.provideGetAllSpellsActivity().handleRequest(request)

--- a/app/src/main/java/dev/tdwalsh/project/tabletopBeholder/lambda/spell/UpdateSpellLambda.java
+++ b/app/src/main/java/dev/tdwalsh/project/tabletopBeholder/lambda/spell/UpdateSpellLambda.java
@@ -2,20 +2,31 @@ package dev.tdwalsh.project.tabletopBeholder.lambda.spell;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
+import dev.tdwalsh.project.tabletopBeholder.activity.spell.request.CreateSpellRequest;
 import dev.tdwalsh.project.tabletopBeholder.activity.spell.request.UpdateSpellRequest;
 import dev.tdwalsh.project.tabletopBeholder.activity.spell.result.UpdateSpellResult;
+import dev.tdwalsh.project.tabletopBeholder.lambda.AuthenticatedLambdaRequest;
 import dev.tdwalsh.project.tabletopBeholder.lambda.LambdaActivityRunner;
 import dev.tdwalsh.project.tabletopBeholder.lambda.LambdaRequest;
 import dev.tdwalsh.project.tabletopBeholder.lambda.LambdaResponse;
 
 public class UpdateSpellLambda
         extends LambdaActivityRunner<UpdateSpellRequest, UpdateSpellResult>
-        implements RequestHandler<LambdaRequest<UpdateSpellRequest>, LambdaResponse> {
+        implements RequestHandler<AuthenticatedLambdaRequest<UpdateSpellRequest>, LambdaResponse> {
 
     @Override
-    public LambdaResponse handleRequest(LambdaRequest<UpdateSpellRequest> input, Context context) {
+    public LambdaResponse handleRequest(AuthenticatedLambdaRequest<UpdateSpellRequest> input, Context context) {
         return super.runActivity(
-                () -> input.fromBody(UpdateSpellRequest.class),
+                () ->
+                {
+                    UpdateSpellRequest stageRequest = input.fromBody(UpdateSpellRequest.class);
+
+                    return input.fromUserClaims(claims ->
+                            UpdateSpellRequest.builder()
+                                    .withUserEmail(claims.get("email"))
+                                    .withSpell(stageRequest.getSpell())
+                                    .build());
+                },
                 (request, serviceComponent) ->
                         serviceComponent.provideUpdateSpellActivity().handleRequest(request)
         );


### PR DESCRIPTION
Description
---
Previously, this app was expecting to receive the hash key `userEmail` in the path of each API call, but that method is needlessly insecure. All `Spell` lambdas, request objects, and activity classes have been refactored to use the Cognito-authenticated e-mail address delivered in the bearer token. This ensures that a user will not be able to interact with another user's data via an api call.