### PR TITLE
Fixed notification bug

### DIFF
--- a/web/src/pages/runEncounterScripts.js
+++ b/web/src/pages/runEncounterScripts.js
@@ -382,7 +382,7 @@ const EMPTY_DATASTORE_STATE = {
         }
          var notifications = document.getElementById('notification-list');
          notifications.innerHTML = '';
-         if(encounter?.messageQueue.length > 0) {
+         if(encounter?.messageQueue?.length > 0) {
             for(var message of encounter.messageQueue) {
                 var messageLine = `<li class="list-group-item">${message}</li>`
             }


### PR DESCRIPTION
Description
---
- Added optional chaining for `encounter.messageQueue.length` so a null queue (versus just empty) would not cause the front-end to error out.